### PR TITLE
feat: support auto-activate current directory (CWD) on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A [Yazi](https://github.com/sxyazi/yazi) plugin for automatic session persistenc
 The plugin saves Yazi workspace state on exit and restores it on startup:
  - Open tabs with their working directories
  - Per-tab view settings: sorting mode, linemode, hidden file visibility
- - Active tab selection
+ - Activate cwd tab: automatically switches to the tab matching the startup directory or creates a new tab if it's not in the saved session
 
 ## Installation
 ```bash

--- a/main.lua
+++ b/main.lua
@@ -34,7 +34,8 @@ end)
 
 -- restore_session
 local _restore_session = ya.sync(function(state)
-  session = state.session
+  local session = state.session
+  local start_cwd = tostring(cx.active.current.cwd):gsub("\\", "/")
 
   for idx, tab in ipairs(session.tabs) do
     if idx == 1 then
@@ -47,8 +48,21 @@ local _restore_session = ya.sync(function(state)
     ya.emit("hidden", { tab.show_hidden })
   end
 
-  ya.emit("tab_switch", { session.active_idx - 1 })
-    
+  -- activate existed tab of cwd or create one if not found
+  local found_idx = nil
+  for idx, tab in ipairs(session.tabs) do
+    if tab.cwd == start_cwd then
+      found_idx = idx
+      break
+    end
+  end
+
+  if found_idx then
+    ya.emit("tab_switch", { found_idx - 1 })
+  else
+    ya.emit("tab_create", { start_cwd })
+  end
+
   state.restored = true
 end)
 


### PR DESCRIPTION
# Background
Users often launch Yazi from a specific project or directory. This change ensures that the directory they are currently in is always the focused one upon startup, providing a more seamless transition while still preserving their previous session's state.

# Summary
This PR enhances the session restoration logic to intelligently handle the current working directory (CWD) at startup.
- Automatic Tab Matching: When Yazi starts, the plugin now detects the current directory. If a tab with the same path exists in the saved session, it automatically switches to that tab.
- Dynamic Tab Creation: If the startup directory is not found in the saved session tabs, a new tab is created for that directory automatically.
- With argument support: If Yazi starts with a given directory argument, it will be recognized as cwd as well.

Resolves #1 